### PR TITLE
Improve clambake land UX - Handle GitHub Auto-Closed Issues and Provide Better Feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
+ "chrono",
  "clap",
  "exponential-backoff",
  "octocrab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.99"
 async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5.45", features = ["derive"] }
 octocrab = "0.44.1"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- ✅ Fixed root cause: GitHub auto-closes issues via PR merges, but old logic only looked at open issues
- ✅ Smart default behavior: Include both open and recently closed issues (no flags needed for common case)
- ✅ Dramatically improved UX with clear explanations and helpful next steps
- ✅ Added --dry-run, --verbose, --open-only, and --days options for power users

## Key Changes
**Default Behavior (Happy Path)**
```bash
clambake land  # Now includes recently closed issues by default
```

**New Command Options**
```bash
clambake land --dry-run --verbose     # Safe preview with details
clambake land --open-only             # Exclude auto-closed issues  
clambake land --days 14               # Look back 14 days instead of 7
```

**Better UX - Before vs After**
```bash
# ❌ Before: Confusing
No completed work found

# ✅ After: Clear and actionable
💡 This could mean:
   → All work is still in progress (check: clambake status)  
   → No auto-closed issues found in last 7 days
🎯 NEXT STEPS:
   → Check active work: clambake status
   → Look further back: clambake land --days 14
```

## Test plan
- [x] Build compiles successfully 
- [x] Help text shows new options correctly
- [x] Default behavior includes closed issues (smart default)
- [x] --dry-run mode works as expected
- [x] --verbose shows detailed scan information
- [x] --open-only excludes closed issues
- [x] Better UX messaging and next-step guidance

Resolves #32

🤖 Generated with [Claude Code](https://claude.ai/code)