### PR TITLE
Fix clambake land to detect auto-closed issues needing agent label cleanup

### DIFF
--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait GitHubOps {
     async fn fetch_issues(&self) -> Result<Vec<octocrab::models::issues::Issue>, GitHubError>;
+    async fn fetch_issues_with_state(&self, state: Option<octocrab::params::State>) -> Result<Vec<octocrab::models::issues::Issue>, GitHubError>;
     async fn assign_issue(&self, issue_number: u64, assignee: &str) -> Result<(), GitHubError>;
     async fn add_label_to_issue(&self, issue_number: u64, label: &str) -> Result<(), GitHubError>;
     async fn create_branch(&self, branch_name: &str, from_branch: &str) -> Result<(), GitHubError>;
@@ -191,10 +192,14 @@ impl GitHubClient {
     }
 
     pub async fn fetch_issues(&self) -> Result<Vec<octocrab::models::issues::Issue>, GitHubError> {
+        self.fetch_issues_with_state(None).await
+    }
+
+    pub async fn fetch_issues_with_state(&self, state: Option<octocrab::params::State>) -> Result<Vec<octocrab::models::issues::Issue>, GitHubError> {
         let issues = self.octocrab
             .issues(&self.owner, &self.repo)
             .list()
-            .state(octocrab::params::State::Open)
+            .state(state.unwrap_or(octocrab::params::State::Open))
             .send()
             .await?;
             
@@ -337,6 +342,10 @@ impl GitHubClient {
 impl GitHubOps for GitHubClient {
     async fn fetch_issues(&self) -> Result<Vec<octocrab::models::issues::Issue>, GitHubError> {
         self.fetch_issues().await
+    }
+    
+    async fn fetch_issues_with_state(&self, state: Option<octocrab::params::State>) -> Result<Vec<octocrab::models::issues::Issue>, GitHubError> {
+        self.fetch_issues_with_state(state).await
     }
     
     async fn assign_issue(&self, issue_number: u64, assignee: &str) -> Result<(), GitHubError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -784,8 +784,12 @@ struct OngoingWork {
 async fn detect_completed_work(client: &github::GitHubClient, include_closed: bool, days: u32, verbose: bool) -> Result<Vec<CompletedWork>, github::GitHubError> {
     let mut completed = Vec::new();
     
-    // Get all issues with agent labels  
-    let issues = client.fetch_issues().await?;
+    // Get all issues (both open and closed) with agent labels when needed 
+    let issues = if include_closed {
+        client.fetch_issues_with_state(Some(octocrab::params::State::All)).await?
+    } else {
+        client.fetch_issues().await?
+    };
     
     let now = chrono::Utc::now();
     let cutoff_date = now - chrono::Duration::days(days as i64);


### PR DESCRIPTION
## Summary
- Fix `clambake land` failing to detect completed work that needs agent label cleanup
- Add support for fetching both open and closed issues when scanning for completed work
- Resolve agent capacity reporting issues where agents appeared busy after work was auto-closed

## Root Cause
The `fetch_issues()` method in GitHubClient only fetched open issues (`State::Open`), but `clambake land` needs to see both open AND closed issues to detect auto-closed issues that still have agent labels.

## Changes Made
- **GitHubClient**: Add `fetch_issues_with_state()` method accepting optional `octocrab::params::State` 
- **Land Command**: Use `State::All` when `include_closed=true` to fetch both open and closed issues
- **Backward Compatibility**: Keep original `fetch_issues()` method unchanged
- **Trait Support**: Add method to `GitHubOps` trait with implementation

## Test Results
✅ **Issue #35**: Now detected and agent label successfully removed  
✅ **Issue #32**: Now detected and agent label successfully removed  
✅ **Multiple closed issues**: All detected and cleaned up properly  
✅ **Ongoing work**: Issue #37 still properly labeled (no regression)  
✅ **--dry-run mode**: Works correctly with new detection  
✅ **--open-only mode**: Maintains backward compatibility  

## Before/After
**Before**: `clambake land --verbose` showed "No completed work found" despite closed issues having agent labels
**After**: `clambake land --verbose` shows "Found 6 completed work item(s)" and successfully cleans up all agent labels

## Test Plan
- [x] Verify issue #35 and other closed issues are detected and cleaned up
- [x] Confirm agent status shows accurate availability after cleanup  
- [x] Test --dry-run and --open-only modes work correctly
- [x] Ensure no regressions in existing functionality

Fixes #37

🤖 Generated with [Claude Code](https://claude.ai/code)