### PR TITLE
Fix branch naming inconsistency breaking ongoing-work detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1337,7 +1337,7 @@ async fn check_ongoing_work() -> Result<Option<OngoingWork>> {
                         
                     if let Some(issue) = assigned_issues.first() {
                         // Found ongoing work - build status regardless of agent availability
-                        let branch_name = format!("work-{}", issue.number);
+                        let branch_name = format!("agent001/{}", issue.number);
                         
                         // Check if we're currently on this branch or if it exists
                         let current_branch = get_current_git_branch();


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where  function uses inconsistent branch naming format that breaks ongoing work detection.

- **Problem**: Function used 'work-{issue}' format but the rest of the system uses 'agent001/{issue}' format
- **Fix**: Changed line 1340 in  to use unified 'agent001/{issue}' format
- **Impact**: Ongoing work detection now works correctly, fixing workflow coordination

Resolves #46

## Changes
- Updated branch naming format in  function
- Ensures consistent naming across all modules
- Enables proper ongoing work detection

## Test Plan
- [x] Code compiles successfully  
- [x] Clambake binary runs without errors
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized ongoing-work branch naming to agent001/<issue_number>.
  * Status display now reflects the new naming: shows “Currently working (on branch)” when checked out, “Branch exists (not checked out)” when present but not active, and “Assigned (branch not created yet)” otherwise.
  * Legacy work-<n> branches are no longer recognized as ongoing work, which may change displayed statuses until branches are updated to the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->