### PR TITLE
Fix route:land assignment logic to prevent assignee overwrites

### DIFF
--- a/src/agents/router.rs
+++ b/src/agents/router.rs
@@ -114,8 +114,13 @@ impl AgentRouter {
                     assigned_agent: agent.clone(),
                 };
                 
-                // Assign to GitHub user (human) and create work branch  
-                self.coordinator.assign_agent_to_issue(&agent.id, issue.number).await?;
+                // Check if this is a route:land task - if so, skip assignment
+                let is_route_land = issue.labels.iter().any(|label| label.name == "route:land");
+                
+                if !is_route_land {
+                    // Only assign for non-route:land tasks
+                    self.coordinator.assign_agent_to_issue(&agent.id, issue.number).await?;
+                }
                 
                 assignments.push(assignment);
             }
@@ -183,10 +188,12 @@ impl AgentRouter {
             .into_iter()
             .filter(|issue| {
                 let is_open = issue.state == octocrab::models::IssueState::Open;
-                let has_route_label = issue.labels.iter()
+                let has_route_ready = issue.labels.iter()
                     .any(|label| label.name == "route:ready");
+                let has_route_land = issue.labels.iter()
+                    .any(|label| label.name == "route:land");
                 
-                if !is_open || !has_route_label {
+                if !is_open || (!has_route_ready && !has_route_land) {
                     return false;
                 }
                 
@@ -222,8 +229,16 @@ impl AgentRouter {
         // Get the first available agent and the highest priority issue
         let available_agents = self.coordinator.get_available_agents().await?;
         if let (Some(issue), Some(agent)) = (available_issues.first(), available_agents.first()) {
-            // If unassigned, assign it. If already assigned to me, just create branch
-            if issue.assignee.is_none() {
+            // Check if this is a route:land task - if so, skip assignment but still create branch
+            let is_route_land = issue.labels.iter().any(|label| label.name == "route:land");
+            
+            if is_route_land {
+                // For route:land tasks, preserve original assignee and just create branch
+                let branch_name = format!("{}/{}", agent.id, issue.number);
+                println!("🌿 Creating agent branch: {}", branch_name);
+                let _ = self.github_client.create_branch(&branch_name, "main").await;
+            } else if issue.assignee.is_none() {
+                // For route:ready tasks, assign if unassigned
                 self.coordinator.assign_agent_to_issue(&agent.id, issue.number).await?;
             } else {
                 // Already assigned to me, just create branch
@@ -253,7 +268,12 @@ impl AgentRouter {
         let available_agents = self.coordinator.get_available_agents().await?;
         
         if let Some(agent) = available_agents.first() {
-            self.coordinator.assign_agent_to_issue(&agent.id, issue.number).await?;
+            // Check if this is a route:land task - if so, skip assignment
+            let is_route_land = issue.labels.iter().any(|label| label.name == "route:land");
+            
+            if !is_route_land {
+                self.coordinator.assign_agent_to_issue(&agent.id, issue.number).await?;
+            }
             
             Ok(Some(RoutingAssignment {
                 issue,


### PR DESCRIPTION
## Summary
- Fixed pop_any_available_task to include route:land issues but skip GitHub assignment
- Fixed route_issues_to_agents to preserve original assignee for route:land tasks  
- Fixed route_specific_issue to skip assignment for route:land issues

## Test plan
- [x] Code compiles successfully
- [x] Binary builds and runs without errors
- [x] Linting passes with only style warnings
- [x] Logic verified to skip assignment only for route:land labeled issues

Fixes issue #45 where route:land tasks were being reassigned to current user instead of preserving original assignee.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the route:land label: issues are prioritized highest and trigger immediate branch creation without assigning an agent.
  * route:land issues are always considered routable; route:ready issues are assigned only if unassigned, otherwise proceed directly to branch creation.
  * route:human-only issues continue to be excluded from automated routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->