### PR TITLE
[UNBLOCKER] #44: Implement Two-Phase clambake land Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "clap",
  "exponential-backoff",
  "octocrab",
+ "once_cell",
  "predicates",
  "serde",
  "serde_json",

--- a/src/agents/router.rs
+++ b/src/agents/router.rs
@@ -77,9 +77,13 @@ impl AgentRouter {
     fn get_issue_priority(&self, issue: &Issue) -> u32 {
         // Priority based on labels: higher number = higher priority
         
-        // Highest priority: route:land tasks (Phase 2 completion)
-        if issue.labels.iter().any(|label| label.name == "route:land") {
-            100 // Maximum priority - merge-ready work
+        // Absolute highest priority: route:unblocker (critical infrastructure issues)
+        if issue.labels.iter().any(|label| label.name == "route:unblocker") {
+            200 // Absolute maximum priority - system blockers
+        }
+        // Second highest priority: route:land tasks (Phase 2 completion)
+        else if issue.labels.iter().any(|label| label.name == "route:land") {
+            100 // High priority - merge-ready work
         }
         // Standard priority labels for route:ready tasks
         else if issue.labels.iter().any(|label| label.name == "route:priority-high") {


### PR DESCRIPTION
## Summary
## Objective
Enhance `clambake land` to support the two-phase workflow: Phase 1 (create PR) and Phase 2 (complete merge), making it the one-stop command for landing code.


## Changes Made
- 2 commit(s) implementing the solution
- Changes ready for review and integration

## Test Plan  
- [x] Code compiles and builds successfully
- [x] Changes tested locally
- [x] Ready for code review

Fixes #44

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a two-phase landing workflow with automatic PR creation when work is ready.
  - Adds dry-run previews for landing actions and clearer user-facing messages.
  - Expands init to set up configuration and required GitHub labels.
- Enhancements
  - Updates routing to prioritize “unblocker” issues above all others, with “land” next.
  - Improves cleanup flow, including label removal and completion notes.
  - Adds readiness checks for branches and basic rate-limit status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->