### PR TITLE
[IMPROVEMENT] Harden rate limit calculation math

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -674,7 +674,12 @@ async fn status_command() -> Result<()> {
             println!("───────────────────");
             match get_github_rate_limit(router.get_github_client()).await {
                 Ok((remaining, total, reset_time)) => {
-                    let usage_percent = ((total - remaining) as f32 / total as f32 * 100.0) as u32;
+                    let used = total.saturating_sub(remaining);
+                    let usage_percent = if total > 0 {
+                        (((used as f32 / total as f32) * 100.0).round() as u32).min(100)
+                    } else {
+                        0
+                    };
                     
                     if remaining > 1000 {
                         println!(" 🟢 Rate limit: {}/{} requests remaining ({}% used)", remaining, total, usage_percent);


### PR DESCRIPTION
## Summary
- Use `saturating_sub` to prevent underflow when remaining > total
- Add division by zero protection for rate limit calculation
- Round percentage before casting to u32 for better accuracy  
- Clamp percentage to max 100 to prevent overflow display

## Test plan
- [x] Code builds successfully
- [x] Rate limit calculation displays correctly in `clambake status`
- [x] Edge cases handled (zero division, underflow)

Fixes issue #65 - CodeRabbit feedback on rate limit calculation reliability

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GitHub rate-limit usage display to prevent negative/overflow values.
  * Now calculates usage as used = total − remaining, showing a rounded percentage only when total > 0.
  * Clamps displayed percentage to a maximum of 100% and safely falls back to 0% when total is zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->