### PR TITLE
Show reminder when popping task while already working on something

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -589,6 +589,29 @@ async fn pop_task_command(mine_only: bool, bundle_branches: bool, auto_approve: 
         return bundle_all_branches(auto_approve).await;
     }
     
+    // Check if we're already on a work branch
+    if let Some(current_branch) = get_current_git_branch() {
+        if let Some((agent_id, issue_number_str)) = current_branch.split_once('/') {
+            if agent_id.starts_with("agent") {
+                if let Ok(issue_number) = issue_number_str.parse::<u64>() {
+                    println!("⚠️  You're already working on something!");
+                    println!();
+                    println!("🌿 Current branch: {}", current_branch);
+                    println!("📋 Working on: Issue #{}", issue_number);
+                    println!();
+                    println!("💡 Suggested actions:");
+                    println!("   → Check progress: clambake status");
+                    println!("   → Complete work: clambake land");
+                    println!("   → Switch to main: git checkout main");
+                    println!("   → Force new task: clambake pop --force (not yet implemented)");
+                    println!();
+                    println!("🎯 To work on multiple issues, complete current work first or switch branches.");
+                    return Ok(());
+                }
+            }
+        }
+    }
+    
     if mine_only {
         println!("🎯 Popping next task assigned to you...");
     } else {


### PR DESCRIPTION
## Summary
- Detects when user is on active agent work branch (agent{id}/{issue} format)
- Shows helpful reminder message with current branch and issue number  
- Suggests appropriate next actions (status, land, checkout main)
- Prevents assignment of new tasks when already working on something
- Does not interfere with normal workflow when not on work branch
- Works with both 'clambake pop' and 'clambake pop --mine' commands

## Test plan
- [x] Shows reminder when on agent work branch (agent001/25)
- [x] Normal behavior when on main branch
- [x] Normal behavior when on non-agent branches (feature/test-branch)
- [x] Works with both --mine flag and regular pop
- [x] Doesn't interfere with bundle branches workflow

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

Fixes #25