### PR TITLE
[REFACTOR] Replace ambiguous route:land label with route:ready_to_merge

### DIFF
--- a/src/agents/router.rs
+++ b/src/agents/router.rs
@@ -180,8 +180,8 @@ mod tests {
         // Test the priority logic by checking labels directly
         // This avoids constructing complex Issue structs
         
-        // Test route:land priority (should be 100)
-        assert_eq!(get_priority_from_labels(&["route:land"]), 100);
+        // Test route:ready_to_merge priority (should be 100)
+        assert_eq!(get_priority_from_labels(&["route:ready_to_merge"]), 100);
         
         // Test route:priority-high (should be 3)
         assert_eq!(get_priority_from_labels(&["route:priority-high"]), 3);
@@ -213,7 +213,7 @@ mod tests {
         // Mirror the logic in fetch_routable_issues's filter (minus PR check)
         let is_open = issue.state == IssueState::Open;
         let has_route_ready = issue.labels.iter().any(|l| l.name == "route:ready");
-        let has_route_land = issue.labels.iter().any(|l| l.name == "route:land");
+        let has_route_land = issue.labels.iter().any(|l| l.name == "route:ready_to_merge");
         let has_agent_label = issue.labels.iter().any(|l| l.name.starts_with("agent"));
         let is_human_only = issue.labels.iter().any(|l| l.name == "route:human-only");
         let is_routable = if has_route_land {
@@ -236,11 +236,11 @@ mod tests {
         // route:ready but already has agent label -> excluded  
         assert!(!is_routable_simple("open", &["route:ready", "agent001"], &[]));
         
-        // route:land always routable if open
-        assert!(is_routable_simple("open", &["route:land"], &[]));
+        // route:ready_to_merge always routable if open
+        assert!(is_routable_simple("open", &["route:ready_to_merge"], &[]));
         
         // Closed issue excluded regardless of labels
-        assert!(!is_routable_simple("closed", &["route:land"], &[]));
+        assert!(!is_routable_simple("closed", &["route:ready_to_merge"], &[]));
         
         // Human-only excluded for route:ready unassigned
         assert!(!is_routable_simple("open", &["route:ready", "route:human-only"], &[]));
@@ -253,7 +253,7 @@ mod tests {
     fn is_routable_simple(state: &str, labels: &[&str], _assignees: &[&str]) -> bool {
         let is_open = state == "open";
         let has_route_ready = labels.iter().any(|&l| l == "route:ready");
-        let has_route_land = labels.iter().any(|&l| l == "route:land");
+        let has_route_land = labels.iter().any(|&l| l == "route:ready_to_merge");
         let has_agent_label = labels.iter().any(|&l| l.starts_with("agent"));
         let is_human_only = labels.iter().any(|&l| l == "route:human-only");
         
@@ -275,7 +275,7 @@ mod tests {
             ("low", get_priority_from_labels(&["route:priority-low", "route:ready"])),
             ("high", get_priority_from_labels(&["route:priority-high", "route:ready"])), 
             ("medium", get_priority_from_labels(&["route:priority-medium", "route:ready"])),
-            ("land", get_priority_from_labels(&["route:land"])),
+            ("land", get_priority_from_labels(&["route:ready_to_merge"])),
         ];
         
         // Sort by priority (high to low)

--- a/src/agents/routing/coordination.rs
+++ b/src/agents/routing/coordination.rs
@@ -78,7 +78,7 @@ impl RoutingCoordinator {
                         tracing::info!(
                             issue_number = issue.number,
                             issue_title = %issue.title,
-                            "Skipped assignment for route:land task"
+                            "Skipped assignment for route:ready_to_merge task"
                         );
                     }
                     

--- a/src/agents/routing/decisions.rs
+++ b/src/agents/routing/decisions.rs
@@ -25,7 +25,7 @@ impl RoutingDecisions {
     }
 
     pub fn is_route_land_task(&self, issue: &Issue) -> bool {
-        issue.labels.iter().any(|label| label.name == "route:land")
+        issue.labels.iter().any(|label| label.name == "route:ready_to_merge")
     }
 
     pub fn is_route_ready_task(&self, issue: &Issue) -> bool {

--- a/src/agents/routing/filters.rs
+++ b/src/agents/routing/filters.rs
@@ -25,7 +25,7 @@ impl IssueFilter {
             let has_route_ready = issue.labels.iter()
                 .any(|label| label.name == "route:ready");
             let has_route_land = issue.labels.iter()
-                .any(|label| label.name == "route:land");
+                .any(|label| label.name == "route:ready_to_merge");
             let has_route_unblocker = issue.labels.iter()
                 .any(|label| label.name == "route:unblocker");
             let has_route_review = issue.labels.iter()
@@ -87,7 +87,7 @@ impl IssueFilter {
             let has_route_ready = issue.labels.iter()
                 .any(|label| label.name == "route:ready");
             let has_route_land = issue.labels.iter()
-                .any(|label| label.name == "route:land");
+                .any(|label| label.name == "route:ready_to_merge");
             let has_route_unblocker = issue.labels.iter()
                 .any(|label| label.name == "route:unblocker");
             let has_route_review = issue.labels.iter()

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -210,7 +210,7 @@ impl GitHubClient {
     }
 
     /// Check if an issue has an open PR that references it
-    /// Returns true if the issue has an open PR WITHOUT route:land label
+    /// Returns true if the issue has an open PR WITHOUT route:ready_to_merge label
     pub async fn issue_has_blocking_pr(&self, issue_number: u64) -> Result<bool, GitHubError> {
         let open_prs = self.fetch_open_pull_requests().await?;
         self.issues.issue_has_blocking_pr(issue_number, &open_prs).await

--- a/src/github/issues.rs
+++ b/src/github/issues.rs
@@ -97,7 +97,7 @@ impl IssueHandler {
     }
 
     /// Check if an issue has an open PR that references it
-    /// Returns true if the issue has an open PR WITHOUT route:land label
+    /// Returns true if the issue has an open PR WITHOUT route:ready_to_merge label
     pub async fn issue_has_blocking_pr(&self, issue_number: u64, open_prs: &[octocrab::models::pulls::PullRequest]) -> Result<bool, GitHubError> {
         use regex::Regex;
         use std::sync::OnceLock;
@@ -147,12 +147,12 @@ impl IssueHandler {
             // Check if this PR references the issue number using optimized regex patterns
             if let Some(body) = &pr.body {
                 if pr_references_issue(body, issue_number) {
-                    // Check if this PR has route:land label
+                    // Check if this PR has route:ready_to_merge label
                     let has_route_land = pr.labels.as_ref()
-                        .map(|labels| labels.iter().any(|label| label.name == "route:land"))
+                        .map(|labels| labels.iter().any(|label| label.name == "route:ready_to_merge"))
                         .unwrap_or(false);
                     
-                    // If PR references the issue but doesn't have route:land, it's blocking
+                    // If PR references the issue but doesn't have route:ready_to_merge, it's blocking
                     if !has_route_land {
                         return Ok(true);
                     }

--- a/src/priority.rs
+++ b/src/priority.rs
@@ -14,7 +14,7 @@ pub enum Priority {
     High = 3,
     /// route:priority-very-high (4)
     VeryHigh = 4,
-    /// route:land - merge-ready work (100)
+    /// route:ready_to_merge - merge-ready work (100)
     MergeReady = 100,
     /// route:unblocker - critical system issues (200)
     Unblocker = 200,
@@ -28,7 +28,7 @@ impl Priority {
         for label in labels {
             let priority = match label.as_ref() {
                 "route:unblocker" => Priority::Unblocker,
-                "route:land" => Priority::MergeReady,
+                "route:ready_to_merge" => Priority::MergeReady,
                 "route:priority-very-high" => Priority::VeryHigh,
                 "route:priority-high" => Priority::High,
                 "route:priority-medium" => Priority::Medium,
@@ -74,8 +74,8 @@ mod tests {
         // Test unblocker (highest)
         assert_eq!(Priority::from_labels(&["route:unblocker"]), Priority::Unblocker);
         
-        // Test land (second highest)
-        assert_eq!(Priority::from_labels(&["route:land"]), Priority::MergeReady);
+        // Test ready_to_merge (second highest)
+        assert_eq!(Priority::from_labels(&["route:ready_to_merge"]), Priority::MergeReady);
         
         // Test standard priorities
         assert_eq!(Priority::from_labels(&["route:priority-very-high"]), Priority::VeryHigh);

--- a/src/workflows/state_machine.rs
+++ b/src/workflows/state_machine.rs
@@ -168,7 +168,7 @@ impl StateMachine {
         let previous_state = AgentState::Available;
         let new_state = AgentState::ReadyToLand(issue_url.to_string());
         
-        // Phase 2: Agent picks up route:land task to complete final merge
+        // Phase 2: Agent picks up route:ready_to_merge task to complete final merge
         println!("🔄 Phase 2: Starting landing for agent {} issue {}", agent_id, issue_url);
         
         self.coordinator.update_agent_state(agent_id, new_state.clone()).await?;
@@ -187,7 +187,7 @@ impl StateMachine {
         // In production, this would:
         // 1. Merge PR to main branch
         // 2. Close issue
-        // 3. Remove route:land label
+        // 3. Remove route:ready_to_merge label
         // 4. Clean up branch
         // 5. Free agent
         // All atomically with rollback on failure
@@ -232,13 +232,13 @@ impl StateMachine {
     }
 
     async fn complete_final_integration(&self, issue_number: u64) -> Result<(), GitHubError> {
-        // Complete the final integration by removing route:land label and closing issue
+        // Complete the final integration by removing route:ready_to_merge label and closing issue
         use std::process::Command;
         
         let repo = format!("{}/{}", self.github_client.owner(), self.github_client.repo());
-        // Remove route:land label
+        // Remove route:ready_to_merge label
         let output = Command::new("gh")
-            .args(&["issue", "edit", &issue_number.to_string(), "-R", &repo, "--remove-label", "route:land"])
+            .args(&["issue", "edit", &issue_number.to_string(), "-R", &repo, "--remove-label", "route:ready_to_merge"])
             .output();
         
         match output {
@@ -247,7 +247,7 @@ impl StateMachine {
                     let error_msg = String::from_utf8_lossy(&result.stderr);
                     return Err(GitHubError::IoError(std::io::Error::new(
                         std::io::ErrorKind::Other,
-                        format!("Failed to remove route:land label: {}", error_msg)
+                        format!("Failed to remove route:ready_to_merge label: {}", error_msg)
                     )));
                 }
             }

--- a/tests/clambake_peek_bug_reproduction.rs
+++ b/tests/clambake_peek_bug_reproduction.rs
@@ -92,12 +92,12 @@ async fn test_correct_behavior_after_agent_completes_work() {
 
 #[tokio::test] 
 async fn test_route_land_issues_should_not_appear_in_new_work_queue() {
-    // GIVEN: An issue that is merge-ready (route:land) 
+    // GIVEN: An issue that is merge-ready (route:ready_to_merge) 
     let merge_ready_issue = fixtures::create_issue_with_labels(
         95,
         "[UNBLOCKER] Add comprehensive state management regression tests",
         vec![
-            "route:land".to_string(),      // Merge-ready
+            "route:ready_to_merge".to_string(),      // Merge-ready
             "route:priority-high".to_string(),
         ],
         Some("johnhkchen".to_string()), // Still assigned for merge completion
@@ -119,7 +119,7 @@ async fn test_route_land_issues_should_not_appear_in_new_work_queue() {
     assert_eq!(new_work_queue[0].number, 97, "Should be the new work issue");
     
     let has_merge_ready = new_work_queue.iter()
-        .any(|issue| issue.labels.iter().any(|l| l.name == "route:land"));
+        .any(|issue| issue.labels.iter().any(|l| l.name == "route:ready_to_merge"));
     assert!(!has_merge_ready, "Merge-ready work should not appear in new work queue");
 }
 
@@ -131,7 +131,7 @@ fn filter_routable_issues_logic(issues: &[octocrab::models::issues::Issue]) -> V
             let is_open = issue.state == octocrab::models::IssueState::Open;
             
             let has_route_ready = issue.labels.iter().any(|l| l.name == "route:ready");
-            let has_route_land = issue.labels.iter().any(|l| l.name == "route:land");  
+            let has_route_land = issue.labels.iter().any(|l| l.name == "route:ready_to_merge");  
             let has_route_unblocker = issue.labels.iter().any(|l| l.name == "route:unblocker");
             
             let has_agent_label = issue.labels.iter().any(|l| l.name.starts_with("agent"));

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -125,18 +125,18 @@ pub fn filter_human_available_issues<'a>(issues: &'a [Issue], current_user: &str
         .collect()
 }
 
-/// Create a completed issue (with route:land label indicating merge-ready)
+/// Create a completed issue (with route:ready_to_merge label indicating merge-ready)
 pub fn create_completed_issue(number: u64, title: &str) -> Issue {
     let mut base_issue = load_test_issues()[0].clone();
     
     base_issue.number = number;
     base_issue.title = title.to_string();
     
-    // Create route:land label to indicate completed work
+    // Create route:ready_to_merge label to indicate completed work
     let mut land_label = base_issue.labels[0].clone();
-    land_label.name = "route:land".to_string();
+    land_label.name = "route:ready_to_merge".to_string();
     
-    // Remove agent labels and add route:land
+    // Remove agent labels and add route:ready_to_merge
     base_issue.labels = base_issue.labels.into_iter()
         .filter(|label| !label.name.starts_with("agent"))
         .collect();
@@ -171,12 +171,12 @@ pub fn filter_assignable_issues(issues: &[Issue]) -> Vec<&Issue> {
             let has_route_ready = issue.labels.iter()
                 .any(|label| label.name == "route:ready");
             let has_route_land = issue.labels.iter()
-                .any(|label| label.name == "route:land");
+                .any(|label| label.name == "route:ready_to_merge");
             let has_agent_label = issue.labels.iter()
                 .any(|label| label.name.starts_with("agent"));
             
             // Issue is assignable if it's open, has route:ready, 
-            // but NOT route:land (completed) and NOT already assigned to agent
+            // but NOT route:ready_to_merge (completed) and NOT already assigned to agent
             is_open && has_route_ready && !has_route_land && !has_agent_label
         })
         .collect()

--- a/tests/github_api_failure_tests.rs.backup
+++ b/tests/github_api_failure_tests.rs.backup
@@ -279,7 +279,7 @@ mod tests {
         let mut failed_calls = 0;
         
         for _ in 0..10 {
-            match client.add_label_to_issue(95, "route:land").await {
+            match client.add_label_to_issue(95, "route:ready_to_merge").await {
                 Ok(()) => successful_calls += 1,
                 Err(_) => failed_calls += 1,
             }

--- a/tests/router_filtering_it.rs
+++ b/tests/router_filtering_it.rs
@@ -84,16 +84,16 @@ fn route_ready_with_agent_label_excluded() {
 
 #[test]
 fn route_land_always_routable_if_open() {
-    let issue = make_issue(102, IssueState::Open, vec!["route:land"], None);
+    let issue = make_issue(102, IssueState::Open, vec!["route:ready_to_merge"], None);
     let is_open = issue.state == IssueState::Open;
-    let has_route_land = issue.labels.iter().any(|l| l.name == "route:land");
+    let has_route_land = issue.labels.iter().any(|l| l.name == "route:ready_to_merge");
     let is_routable = if has_route_land { true } else { false };
     assert!(is_open && is_routable);
 }
 
 #[test]
 fn closed_issue_never_routable() {
-    let issue = make_issue(103, IssueState::Closed, vec!["route:land"], None);
+    let issue = make_issue(103, IssueState::Closed, vec!["route:ready_to_merge"], None);
     let is_open = issue.state == IssueState::Open;
     assert!(!is_open);
 }

--- a/tests/state_management_regression_tests.rs
+++ b/tests/state_management_regression_tests.rs
@@ -282,7 +282,7 @@ mod tests {
         let client = MockGitHubClient::new("johnhkchen", "clambake");
         
         // When: We add a label to an issue
-        let result = client.add_label_to_issue(95, "route:land").await;
+        let result = client.add_label_to_issue(95, "route:ready_to_merge").await;
         
         // Then: The operation should succeed
         assert!(result.is_ok(), "Label addition should succeed");
@@ -294,7 +294,7 @@ mod tests {
         match &calls[0] {
             GhCliCall::AddLabel { issue_number, label, repo_targeted, command_args } => {
                 assert_eq!(*issue_number, 95);
-                assert_eq!(label, "route:land");
+                assert_eq!(label, "route:ready_to_merge");
                 assert!(repo_targeted, "gh CLI call must include -R repo targeting");
                 assert!(command_args.contains(&"-R".to_string()));
                 assert!(command_args.contains(&"johnhkchen/clambake".to_string()));
@@ -415,7 +415,7 @@ mod tests {
     
     #[tokio::test]
     async fn test_completed_work_never_reassigned_detection() {
-        // Given: Issues with completed work (route:land label indicates merge-ready)
+        // Given: Issues with completed work (route:ready_to_merge label indicates merge-ready)
         let completed_issue = fixtures::create_completed_issue(93, "Fix state management bug");
         let ready_issue = fixtures::create_ready_issue(95, "Add regression tests");
         
@@ -444,8 +444,8 @@ mod tests {
         // 1. Assign work to agent
         let _ = client.add_label_to_issue(95, "agent001").await;
         
-        // 2. Complete work (add route:land label)
-        let _ = client.add_label_to_issue(95, "route:land").await;
+        // 2. Complete work (add route:ready_to_merge label)
+        let _ = client.add_label_to_issue(95, "route:ready_to_merge").await;
         
         // 3. Free agent (remove agent label)
         let _ = client.remove_label_from_issue(95, "agent001").await;
@@ -456,7 +456,7 @@ mod tests {
         
         // Verify the sequence
         assert!(matches!(&calls[0], GhCliCall::AddLabel { label, .. } if label == "agent001"));
-        assert!(matches!(&calls[1], GhCliCall::AddLabel { label, .. } if label == "route:land"));
+        assert!(matches!(&calls[1], GhCliCall::AddLabel { label, .. } if label == "route:ready_to_merge"));
         assert!(matches!(&calls[2], GhCliCall::RemoveLabel { label, .. } if label == "agent001"));
         
         // Verify all calls used proper repo targeting

--- a/tests/workflow_integration_tests.rs
+++ b/tests/workflow_integration_tests.rs
@@ -17,7 +17,7 @@ pub enum WorkflowState {
     Ready,           // issue ready for assignment
     Assigned,        // assigned to agent
     Working,         // agent working
-    Completed,       // work completed (route:land)
+    Completed,       // work completed (route:ready_to_merge)
     ReviewReady,     // ready for CodeRabbit review
     Reviewed,        // CodeRabbit review complete
     MergeReady,      // ready for merge


### PR DESCRIPTION
## Summary
- Replaced confusing 'route:land' label with descriptive 'route:ready_to_merge' throughout codebase
- Updated priority mapping, routing logic, GitHub integration, and all test files
- Preserved all functionality while improving clarity and developer experience

## Changes Made
- **Priority System**: Updated `src/priority.rs` to map `route:ready_to_merge` to Priority::MergeReady
- **Routing Logic**: Updated router and routing decision modules to use new label
- **GitHub Integration**: Updated client and issues handling for new label name
- **State Machine**: Updated workflow comments and logic references
- **Tests**: Updated all test files and fixtures to use new label name

## Benefits
- **Clear workflow stages**: route:ready → route:review → route:ready_to_merge
- **Improved clarity**: Self-documenting label that explicitly states its purpose  
- **Better developer experience**: No more confusion about what "land" means
- **Consistent terminology**: Matches other descriptive route labels in the system

## Test Results
- ✅ Code compiles successfully 
- ✅ Priority tests pass confirming correct functionality
- ✅ Router tests pass confirming routing logic works
- ✅ All occurrences systematically replaced

Closes #162

🤖 Generated with [Claude Code](https://claude.ai/code)